### PR TITLE
Remove trailing slashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Optimizely's Developers Site
-You can find the new developer documentation website here: [http://developers.optimizely.com/](http://developers.optimizely.com/)
+You can find the new developer documentation website here: [http://developers.optimizely.com](http://developers.optimizely.com)
 
 ### Prerequisites
 - Have [node.js](https://nodejs.org/) installed.
@@ -29,7 +29,7 @@ npm run gulp
 npm run deploy
 ```
 
-After deploying verify your changes on the live site: [http://developers.optimizely.com/](http://developers.optimizely.com/)
+After deploying verify your changes on the live site: [http://developers.optimizely.com](http://developers.optimizely.com)
 
 ### Troubleshooting
 test

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/optimizely/developers.optimizely.com/issues"
   },
-  "homepage": "https://github.com/optimizely/developers.optimizely.com",
+  "homepage": "http://developers.optimizely.com",
   "dependencies": {
     "compass-mixins": "^0.12.7",
     "highlight.js": "^8.6.0",


### PR DESCRIPTION
@tscanlin - this PR removes trailing slashes from the URL. We were already redirecting to the URL without a trailing slash, so this change just saves users from having to go through a redirect.