### PR TITLE
Uploaded lists -> Uploaded audiences.

### DIFF
--- a/src/content/overview/index.md
+++ b/src/content/overview/index.md
@@ -198,7 +198,7 @@ Technically speaking, a variation is just a snippet of code that can be executed
 
 Customers can filter what type of traffic they'd like to include in an experiment using an *audience*.
 
-On the web, an audience is just a set of AND/OR conditions about a user (e.g. browser type, geography, query parameters) that can be evaluated in real-time when a user visits a web page. Audiences can be saved and re-used for other experiments. You can use *custom dimensions* to manually define conditions by which visitors are assigned to an audience in a web browser, or use *uploaded lists* if you want to target a particular set of user identifiers (e.g. cookies or query parameters).
+On the web, an audience is just a set of AND/OR conditions about a user (e.g. browser type, geography, query parameters) that can be evaluated in real-time when a user visits a web page. Audiences can be saved and re-used for other experiments. You can use *custom dimensions* to manually define conditions by which visitors are assigned to an audience in a web browser, or use *uploaded audiences* if you want to target a particular set of user identifiers (e.g. cookies or query parameters).
 
 *Note:* We do not yet support audiences on iOS and Android, but you can still create your own [custom targeting conditions](https://help.optimizely.com/hc/en-us/articles/202296994#targeting) for an experiment.
 
@@ -208,7 +208,7 @@ On the web, an audience is just a set of AND/OR conditions about a user (e.g. br
 * Learn how to [create custom targeting conditions in an Android app](../ios/reference#-a-name-targeting-a-custom-targeting)
 * Learn how to [create a custom dimension using the REST API](../rest/reference#dimensions)
 * Learn how to [create an audience using the REST API](../rest/reference#audience)
-* Learn how to [use uploaded lists in Optimizely using the REST API](../rest/reference#user_lists)
+* Learn how to [use uploaded audiences in Optimizely using the REST API](../rest/reference#uploaded-audiences)
 
 #### *4. Create a goal*
 

--- a/src/content/rest/reference/lists/0-intro.md
+++ b/src/content/rest/reference/lists/0-intro.md
@@ -1,11 +1,11 @@
 ---
 template: sidebyside
-title: Uploaded lists
-anchor: lists
+title: Uploaded Audiences
+anchor: uploaded-audiences
 ---
 
-An uploaded list is a set of user identifiers that you have uploaded to Optimizely. Membership in a targeting list can be used to define an Optimizely audience, so you can target experiments only to a particular set of users.
+An uploaded audience is a set of user identifiers that you have uploaded to Optimizely. Membership in a targeting list can be used to define an Optimizely audience, so you can target experiments only to a particular set of users.
 
 We currently support three targeting list formats: cookies, query parameters and zip codes.
 
-Uploaded lists are an Enterprise feature and may not be available for your Optimizely account. If you are uncertain whether you have access or would like to request access for development purposes, please email <a href="mailto:developers@optimizely.com">developers@optimizely.com</a>.
+Uploaded audiences are an Enterprise feature and may not be available for your Optimizely account. If you are uncertain whether you have access or would like to request access for development purposes, please email <a href="mailto:developers@optimizely.com">developers@optimizely.com</a>.

--- a/src/content/rest/reference/lists/1-read.md
+++ b/src/content/rest/reference/lists/1-read.md
@@ -4,17 +4,17 @@ endpoint: targeting_lists/123/
 endpoint_prefix: targeting_lists/
 endpoint_option: 123
 type: GET
-title: Read an uploaded list
-anchor: read-list
+title: Read an uploaded audience
+anchor: read-uploaded-audience
 fields:
-  name: A unique, human-readable name for the uploaded list
-  description: A brief description of the uploaded list
-  list_type: The type of uploaded list (`1` = cookies, `2` = query parameters, `3` = zip codes)
+  name: A unique, human-readable name for the uploaded audience
+  description: A brief description of the uploaded audience
+  list_type: The type of uploaded audience (`1` = cookies, `2` = query parameters, `3` = zip codes)
   key_fields: A comma-separated list of cookies (if <b>list&#95;type</b> is `1`) or query parameters (if <b>list&#95;type</b> is `2`) to target on
-  id: The unique identifier for the uploaded list
+  id: The unique identifier for the uploaded audience
   project_id: The unique identifier for the parent Optimizely project
   account_id: The unique identifier for the parent Optimizely account
-  format: Format of the uploaded list (should always be a `csv` file)
+  format: Format of the uploaded audience (should always be a `csv` file)
 response: |
   {
       "name": "List_1",
@@ -28,4 +28,4 @@ response: |
   }
 ---
 
-Get metadata for a single uploaded list.
+Get metadata for a single uploaded audience.

--- a/src/content/rest/reference/lists/2-create.md
+++ b/src/content/rest/reference/lists/2-create.md
@@ -5,8 +5,8 @@ endpoint_prefix: projects/
 endpoint_option: 456
 endpoint_suffix: /targeting_lists
 type: POST
-title: Create an uploaded list
-anchor: create-list
+title: Create an uploaded audience
+anchor: create-uploaded-audience
 request:
   name: "List_1"
   description: "Description of List 1"
@@ -27,9 +27,9 @@ response: |
   }
 ---
 
-Create an uploaded list with the given name and comma-separated set of values.
+Create an uploaded audience with the given name and comma-separated set of values.
 
-`name` must be unique across all lists defined in the current project, and can only contain characters, numbers, hyphens, and underscores.
+`name` must be unique across all audiences defined in the current project, and can only contain characters, numbers, hyphens, and underscores.
 
 `list_type` must take one of the following values:
 
@@ -37,6 +37,6 @@ Create an uploaded list with the given name and comma-separated set of values.
 - `2` Query string
 - `3` Zip code
 
-`list_content` should contain the content of the list in comma-separated format and `format` must be set to `csv`. Currently we limit list sizes to 5MB. If you need to upload larger list sizes, please contact [developers@optimizely.com](mailto:developers@optimizely.com).
+`list_content` should contain the content of the audience in comma-separated format and `format` must be set to `csv`. Currently we limit audience sizes to 5MB. If you need to upload larger audiences, please contact [developers@optimizely.com](mailto:developers@optimizely.com).
 
 All fields are required with the exception of `description`.

--- a/src/content/rest/reference/lists/3-update.md
+++ b/src/content/rest/reference/lists/3-update.md
@@ -4,8 +4,8 @@ endpoint: targeting_lists/123/
 endpoint_prefix: targeting_lists/
 endpoint_option: 123
 type: PUT
-title: Update an uploaded list
-anchor: update-list
+title: Update an uploaded audience
+anchor: update-uploaded-audience
 request:
   name: "List_1"
   description: "New description of List 1"
@@ -26,6 +26,6 @@ response: |
   }
 ---
 
-Overwrite the uploaded list with the provided `id`. Required arguments are identical to creating a new uploaded list.
+Overwrite the uploaded audience with the provided `id`. Required arguments are identical to creating a new uploaded audience.
 
 Note that `name` and `format` cannot be modified.

--- a/src/content/rest/reference/lists/4-delete.md
+++ b/src/content/rest/reference/lists/4-delete.md
@@ -4,7 +4,7 @@ endpoint: targeting_lists/123/
 endpoint_prefix: targeting_lists/
 endpoint_option: 123
 type: DELETE
-title: Delete an uploaded list
-anchor: delete-list
+title: Delete an uploaded audience
+anchor: delete-uploaded-audience
 ---
-Permanently deletes the given uploaded list.
+Permanently deletes the given uploaded audience.

--- a/src/content/rest/reference/lists/5-list.md
+++ b/src/content/rest/reference/lists/5-list.md
@@ -5,8 +5,8 @@ endpoint_prefix: projects/
 endpoint_option: 456
 endpoint_suffix: /targeting_lists/
 type: GET
-title: List uploaded lists in project
-anchor: list-lists
+title: List uploaded audiences in a project
+anchor: list-uploaded-audiences
 response: |
   [
     {
@@ -32,4 +32,4 @@ response: |
   ]
 ---
 
-Show all of the uploaded lists that have been uploaded to a project.
+Show all of the uploaded audiences that have been uploaded to a project.

--- a/src/content/rest/reference/overview/6-changelog.md
+++ b/src/content/rest/reference/overview/6-changelog.md
@@ -3,7 +3,7 @@ template: sidebyside
 title: Change Log
 anchor: changes
 ---
-* **May 11th, 2015**: You can now [upload targeting lists](#lists) via the REST API.
+* **May 11th, 2015**: You can now [upload targeting audiences](#uploaded-audiences) via the REST API.
 * **March 27th, 2015**: You can now retrieve statistics computed by <a target="_blank" href="https://help.optimizely.com/hc/en-us/articles/200039895">Optimizely Stats Engine</a> via the API.
 * **March 19th, 2015**: We have added [OAuth 2.0 support](#oauth) so third party applications can connect with the REST API on behalf of an Optimizely customer.
 * **February 24th, 2015**: You can now [create and edit dimensions](#dimensions) via the REST API.

--- a/src/content/samples/index.concat
+++ b/src/content/samples/index.concat
@@ -13,7 +13,7 @@ sections:
 - stats
 - results
 - audiences
-- user-lists
+- uploaded-audiences
 - technology-integrations
 - helpers
 ---

--- a/src/content/samples/user-lists/0-intro.md
+++ b/src/content/samples/user-lists/0-intro.md
@@ -1,14 +1,14 @@
 ---
 template: inline
-title: Uploaded lists
-anchor: user-lists
+title: Uploaded Audiences
+anchor: uploaded-audiences
 ---
-You can use the [Optimizely REST API](/rest/reference/index.html#lists) to upload
-[user lists](https://help.optimizely.com/hc/en-us/articles/206197347-User-List-Targeting-Create-audiences-based-on-lists-of-data)
+You can use the [Optimizely REST API](/rest/reference/index.html#uploaded-audiences) to upload your
+[user audiences](https://help.optimizely.com/hc/en-us/articles/206197347-User-List-Targeting-Create-audiences-based-on-lists-of-data)
 to Optimizely, which you can use to target experiments and segment results.
 
 To illustrate this functionality, we've built a sample script that queries for records in a Salesforce account and
-uses an uploaded list in Optimizely based on that data, allowing you to, for instance, target an
+uses an uploaded audience in Optimizely based on that data, allowing you to, for instance, target an
 experiment to customers who are in a particular industry according to your Salesforce data.
 
 <a class="btn btn-primary" target="_blank" href="https://github.com/optimizely/optimizely-api-samples/tree/master/salesforce_list_targeting">Visit our README</a>


### PR DESCRIPTION
@tscanlin - Just noticed that [this ticket](https://optimizely.atlassian.net/browse/EDU-487) requested the rename to be `Uploaded Audiences` not `Uploaded Lists`.