### PR TITLE
Rename DCP "keyfield locator" -> "customer ID locator"

### DIFF
--- a/src/content/rest/customer-profiles/alias/2-create.md
+++ b/src/content/rest/customer-profiles/alias/2-create.md
@@ -23,6 +23,6 @@ In this example, it is *678*.  The `customerId` for this call should be the Opti
 *oeu1234.5678*.
 </div>
 
-You do not need to use this API in order for aliases to be created.  If you can populate your
-[datasources](https://help.optimizely.com/hc/en-us/articles/216307487#add)' key field locators with customer IDs,
+You do not need to use this API in order for aliases to be created.  If you configure your
+[datasources](https://help.optimizely.com/hc/en-us/articles/216307487#add) with appropriate customer ID locators,
 Optimizely will automatically alias your customer IDs to Optimizely User IDs (as customers visit your website).

--- a/src/content/rest/reference/dcpdatasources/0-intro.md
+++ b/src/content/rest/reference/dcpdatasources/0-intro.md
@@ -16,11 +16,13 @@ datasource allows you to send data to Optimizely without requiring you to reconc
 of reconciling data of the same customer across datasources can be achieved using the
 [alias](/rest/customer-profiles#alias) operation.
 
-When creating a Datasource, you will provide a key field locator type and name to enable Optimizely to perform aliasing
-for you. A key field locator is a location on your resource (e.g. web-page) where you can place the customer id for a
-particular datasource. Optimizely will read this information for each of your customers and alias each of the datasource
-customer ids to the canonical Optimizely user id (UID) assigned on the customer's device. In the figure, "Email
-Platform" has a key field locator type `cookie`, and name `email_platform_cookie_name`. You will place this datasource's
-customer id in a `cookie` named `email_platform_cookie_name`, which Optimizely can read and alias to the Optimizely UID.
+When creating a datasource, you will provide a customer ID locator (type and name), which tells Optimizely where we can
+find the customer ID on your web pages.  When a customer visits, Optimizely will read their customer ID (for each 
+datasource) and alias it to their Optimizely User ID.
+In the figure, the "Email Platform" datasource has a locator whose type is `cookie` and whose name is 
+`email_platform_cookie_name`.  In order for aliasing to work, you would have to place an appropriate customer ID
+(matching the customer ID for every row that you upload for this datasource) in a `cookie` named 
+`email_platform_cookie_name`.
 
-If you prefer to alias customer IDs by yourself, you can do so using the [alias](/rest/customer-profiles#alias) API.
+If you prefer to alias customer IDs manually, and if you know the corresponding Optimizely User ID for each of your
+customer IDs, you can do so using the [alias](/rest/customer-profiles#alias) API.

--- a/src/content/rest/reference/dcpdatasources/1-read.md
+++ b/src/content/rest/reference/dcpdatasources/1-read.md
@@ -16,9 +16,8 @@ fields:
   dcp_service_id: The DCPService this datasource is associated with
   description: A short description
   is_optimizely: Boolean indicating if this is the Optimizely Datasource
-  keyfield_locator_type: Type of keyfield locator. The keyfield locator is the client location of this Datasource's
-                         customer id. Must be one of `"cookie"`, `"query parameter"`, `"js_variable"`, or `"uid"`.
-  keyfield_locator_name: Name of keyfield locator. Required for all `keyfield_locator_types` except `"uid"`, and must
+  keyfield_locator_type: Type of customer ID locator. Must be one of `"cookie"`, `"query parameter"`, `"js_variable"`, or `"uid"`.
+  keyfield_locator_name: Name of customer ID locator. Required for all `keyfield_locator_types` except `"uid"`, and must
                          match the regular expression `/^[a-zA-Z_][a-zA-Z_0-9\$]*$/`
   last_modified: Last modified date of this Datasource
   name: The name of the Datasource

--- a/src/content/rest/reference/dcpdatasources/2-create.md
+++ b/src/content/rest/reference/dcpdatasources/2-create.md
@@ -38,5 +38,5 @@ Create a Datasource for the specified DCP Service.  The `dcp_service_id` is requ
   - `"query parameter"`
   - `"js_variable"`
   - `"uid"`
-- `keyfield_locator_name`: Name of keyfield locator. Required for all `keyfield_locator_types` except `"uid"`, and must
+- `keyfield_locator_name`: Name of customer ID locator. Required for all `keyfield_locator_types` except `"uid"`, and must
   match the regular expression `/^[a-zA-Z_][a-zA-Z_0-9\$]*$/`.

--- a/src/content/rest/reference/dcpdatasources/3-update.md
+++ b/src/content/rest/reference/dcpdatasources/3-update.md
@@ -39,6 +39,6 @@ Update a Datasource.  The `datasource_id` is required in the URL.
   - `"query parameter"`
   - `"js_variable"`
   - `"uid"`
-- `keyfield_locator_name`: Name of keyfield locator. Required for all `keyfield_locator_types` except `"uid"`, and must
+- `keyfield_locator_name`: Name of customer ID locator. Required for all `keyfield_locator_types` except `"uid"`, and must
   match the regular expression `/^[a-zA-Z_][a-zA-Z_0-9\$]*$/`.
 


### PR DESCRIPTION
@evanWeissOptly and I agree that "customer ID locator" is more indicative of the type of values that we want these locators to point to.

We should update the copy, even if we can't update the `keyfield_locator_type` and `keyfield_locator_name` property names in the API.