### PR TITLE
Fix forwarding URL for Canvas

### DIFF
--- a/src/files/canvas/index.html
+++ b/src/files/canvas/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Optimizely Developers</title>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0;URL=/apps">
+    <meta http-equiv="refresh" content="0;URL=/apps/index.html">
     <meta name="description" content="Optimizely Developer Documentation">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Source+Code+Pro:400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
@jgaul 

fixes bug related to canvas redirection

steps to repro:
1. go to http://developers.optimizely.com/canvas/ 

expected:
should redirect to http://developers.optimizely.com/apps/ 
![image](https://cloud.githubusercontent.com/assets/729524/13678672/c3494aae-e6a4-11e5-9797-0c4f546ca1e5.png)

actual:
redirects to http://developers.optimizely.com/apps (without backslash) and gives 404. 
![image](https://cloud.githubusercontent.com/assets/729524/13678663/bbaf89ca-e6a4-11e5-92a8-009bbd30214a.png)
