### PR TITLE
add flags for navigation to make adding new pages easier

### DIFF
--- a/config.js
+++ b/config.js
@@ -87,39 +87,50 @@ var paths = {
     overview: {
       path: 'overview',
       title: 'Overview',
+      singlePage: true,
     },
     rest: {
       path: 'rest',
       title: 'REST API',
       sections: REST_NAV_SECTIONS,
+      showInHeaderDropdown: true,
     },
     javascript: {
       path: 'javascript',
       title: 'JS API',
       sections: JS_NAV_SECTIONS,
+      showInHeaderDropdown: true,
     },
     ios: {
       path: 'ios',
       title: 'iOS SDK',
       sections: MOBILE_NAV_SECTIONS,
+      showInHeaderDropdown: true,
     },
     android: {
       path: 'android',
       title: 'Android SDK',
       sections: MOBILE_NAV_SECTIONS,
+      showInHeaderDropdown: true,
     },
     server: {
       path: 'server',
       title: 'Server',
       sections: SERVER_NAV_SECTIONS,
+      // Hide if its a hidden section unless its the current path (users go direct to the url)
+      hiddenSection: true,
     },
     integrations: {
       path: 'integrations',
       title: 'Integrations',
+      singlePage: true,
+      showInHeaderDropdown: true,
     },
     apps: {
       path: 'apps',
       title: 'Apps',
+      singlePage: true,
+      showInHeaderDropdown: true,
     },
   },
 };

--- a/src/partials/_header.html
+++ b/src/partials/_header.html
@@ -31,12 +31,7 @@
             </a>
             <ul class="unstyled nav nav--stacked dropdown background--super-dark soft--sides collapsible--small is-collapsed" data-auto-close>
               {% for key, item in paths.navigation %}
-                {% if item.path == 'rest' or item.path == 'javascript' or item.path == 'ios' or item.path == 'android' %}
-                  <li class="push-half">
-                    <a href="/{{ item.path }}/introduction/">{{ item.title }}</a>
-                  </li>
-                {% endif %}
-                {% if item.path == 'integrations' or item.path == 'apps' %}
+                {% if item.showInHeaderDropdown == true %}
                   <li class="push-half">
                     <a href="/{{ item.path }}/">{{ item.title }}</a>
                   </li>

--- a/src/partials/_nav.html
+++ b/src/partials/_nav.html
@@ -3,11 +3,12 @@
   <div class="nav-sidebar">
     <ul class="unstyled nav nav--stacked soft-double delta">
       {% for key, item in paths.navigation %}
-        {% if item.path != 'server' or item.path == 'server' and pathArray[0] == 'server' %}
+        <!-- Hide if its a hidden section unless its the current path (users go direct to the url) -->
+        {% if item.hiddenSection != true or item.path == pathArray[0] %}
         <li class="push--bottom">
-          <a class="main-section{% if item.path == pathArray[0] %} active{% endif %}" href="/{{ item.path }}"{% if item.path != 'samples' and item.path != 'overview' and item.path != 'integrations' and item.path != 'apps' %} data-collapser{% endif %}>{{ item.title }}</a>
-          <!-- TOC for overview, integrations, apps, and code samples -->
-          {% if item.path == 'overview' or item.path == 'integrations' or item.path == 'apps' %}
+          <a class="main-section{% if item.path == pathArray[0] %} active{% endif %}" href="/{{ item.path }}"{% if item.singlePage != true %} data-collapser{% endif %}>{{ item.title }}</a>
+          <!-- TOC for single pages -->
+          {% if item.singlePage == true %}
             <ul class="unstyled nav nav--stacked epsilon toc"></ul>
           {% endif %}
 


### PR DESCRIPTION
@mauerbac @nchilada 

add flags for navigation to make adding new pages easier

I tried to make the flags descriptive, here they are:
- **singlePage:** for sections like Overview, Integration, and Apps
- **showInHeaderDropdown:** for showing things in the Documentation dropdown in the header
- **hiddenSection:** for Server section and other sections we want to hide