### PR TITLE
fix yaml error

### DIFF
--- a/src/content/rest/reference/projects/1-read.md
+++ b/src/content/rest/reference/projects/1-read.md
@@ -11,7 +11,7 @@ fields:
   project_status: Can be `Active` or `Archived`
   account_id: The account the project is associated with
   include_jquery: Either `true` or `false`. If set to `true`, the recommended version (1.11.3) will be used.
-  library: The prefered jQuery library you would like to use with your snippet. We support the following: `jquery-1.6.4-full`, `jquery-1.6.4-trim`, `jquery-1.11.3-full`, and `jquery-1.11.3-trim`. If you do not want to include jQuery, set this field to `none` and `include_jquery` to `false`.
+  library: "The prefered jQuery library you would like to use with your snippet. We support the following: `jquery-1.6.4-full`, `jquery-1.6.4-trim`, `jquery-1.11.3-full`, and `jquery-1.11.3-trim`. If you do not want to include jQuery, set this field to `none` and `include_jquery` to `false`."
   project_javascript: The JavaScript code which runs before Optimizely on all pages, **regardless** of whether or not there is a running experiment.
   enable_force_variation: Set to `true` to enable the [force variation parameter](https://help.optimizely.com/hc/en-us/articles/202480860#force_variations)
   exclude_disabled_experiments: Set to `true` to [remove paused and draft experiments](https://help.optimizely.com/hc/en-us/articles/202480860#draft_pause) from the snippet

--- a/src/content/rest/reference/projects/1-read.md
+++ b/src/content/rest/reference/projects/1-read.md
@@ -11,7 +11,7 @@ fields:
   project_status: Can be `Active` or `Archived`
   account_id: The account the project is associated with
   include_jquery: Either `true` or `false`. If set to `true`, the recommended version (1.11.3) will be used.
-  library: "The prefered jQuery library you would like to use with your snippet. We support the following: `jquery-1.6.4-full`, `jquery-1.6.4-trim`, `jquery-1.11.3-full`, and `jquery-1.11.3-trim`. If you do not want to include jQuery, set this field to `none` and `include_jquery` to `false`."
+  library: The prefered jQuery library you would like to use with your snippet. We support the following `jquery-1.6.4-full`, `jquery-1.6.4-trim`, `jquery-1.11.3-full`, and `jquery-1.11.3-trim`. If you do not want to include jQuery, set this field to `none` and `include_jquery` to `false`.
   project_javascript: The JavaScript code which runs before Optimizely on all pages, **regardless** of whether or not there is a running experiment.
   enable_force_variation: Set to `true` to enable the [force variation parameter](https://help.optimizely.com/hc/en-us/articles/202480860#force_variations)
   exclude_disabled_experiments: Set to `true` to [remove paused and draft experiments](https://help.optimizely.com/hc/en-us/articles/202480860#draft_pause) from the snippet


### PR DESCRIPTION
@mauerbac this was a bit tricky to debug because the YAML parser we use doesn't throw the best errors, but let me try and walk you through my debugging process.

First, I went to travis to see which build broke because every PR should get run/built on travis:
https://travis-ci.org/optimizely/developers.optimizely.com/builds

Then I noticed that the red build was this one:
https://github.com/optimizely/developers.optimizely.com/pull/327/files

So I looked at the changes to see what could have broken the build. Not seeing anything obvious I decided to paste a chunk of the YAML from that file in here to validate it:
http://www.yamllint.com/

It highlighted the line that started with "library: "
and gave me this error:
"(<unknown>): mapping values are not allowed in this context at line 6 column 105"

That also didn't really help much. So I googled a bit until I took another look at the YAML and noticed that the text contained a ":" in it. Apparently YAML doesn't like that, but it was easily fixed by wrapping the text in quotes.

In the future, try and make sure that the site builds correctly locally before merging. But at least the build process is smart enough not to deploy broken code ;). No worries though, yaml issues are the worst. Thanks!