### PR TITLE
Add end statements to Ruby code blocks

### DIFF
--- a/src/content/server/reference/activation/0-intro.md
+++ b/src/content/server/reference/activation/0-intro.md
@@ -49,6 +49,7 @@ code_examples:
         # execute code for variation B
       else
         # execute default code
+      end
   javascript:
     lang: javascript
     request: |

--- a/src/content/server/reference/activation/1-targeting.md
+++ b/src/content/server/reference/activation/1-targeting.md
@@ -57,6 +57,7 @@ code_examples:
         # execute code for variation B
       else
         # execute default code
+      end
 
   javascript:
     lang: javascript


### PR DESCRIPTION
Ruby conditionals require `end` statements as seen here: http://ruby-doc.org/docs/Tutorial/part_02/conditionals.html

Just noticed the docs didn't have these and wanted to correct this quickly.

@mauerbac @delikat @aliabbasrizvi @mikeng13 @vraja2 