### PR TITLE
Update the documentation of the results APIs

### DIFF
--- a/src/content/results/results/0-stats.md
+++ b/src/content/results/results/0-stats.md
@@ -48,7 +48,7 @@ response: |
       "difference": 0.014,
       "difference_confidence_interval_min": 0.008,
       "difference_confidence_interval_max": 0.020,
-      "visitors_until_significance": 100,
+      "visitors_until_statistically_significant": 100,
       "is_revenue": false,
     },
     {
@@ -68,15 +68,16 @@ response: |
       "difference": 0,
       "difference_confidence_interval_min": 0,
       "difference_confidence_interval_max": 0,
-      "visitors_until_significance": 100,
+      "visitors_until_statistically_significant": 100,
       "is_revenue": false,
     }
   ]
 ---
-The /stats endpoint is identical to the [/results](#get-results) endpoint, except that the **confidence** field (i.e. chance to beat baseline) has been replaced with result statistics provided by the <a target="_blank" href="https://help.optimizely.com/hc/en-us/articles/200039895">Optimizely Stats Engine</a>.
+Use the /stats endpoint to get the top-level results of an experiment, computed using the <a target="_blank" href="https://help.optimizely.com/hc/en-us/articles/200039895">Optimizely Stats Engine</a>.
 
 <div class="attention attention--warning push--bottom">
-<b>All experiments started on or after January 21, 2015 have statistics computed by Optimizely Stats Engine.</b> For consistency with the Optimizely results page, we recommend you use the /stats endpoint instead of the /results endpoint for all experiments started on or after January 21, 2015. You can continue to use the /results endpoint for all experiments, regardless of start date.</div>
+<b>Stats Engine is only available for experiments started on or after January 21, 2015.</b> For older experiments, you must use the <a href="#get-results">/results</a> endpoint. Those results will match what you see on the Optimizely results page.
+</div>
 
 The request requires an `experiment_id` and the response contains a list of JSON objects representing every combination of variations and goals that have been defined for that experiment. For example, if there are three variations and two goals defined for an experiment, the response will contain six JSON objects representing each `variation_id` and `goal_id` combination.
 

--- a/src/content/results/results/1-results.md
+++ b/src/content/results/results/1-results.md
@@ -63,10 +63,12 @@ response: |
     },
   ]
 ---
-Use the results endpoint to get the top-level results of an experiment, including number of visitors, number of conversions, and chance to beat baseline for each variation.
+Use the /results endpoint to get the top-level results of an experiment, computed using a traditional t-test.
 
 <div class="attention attention--warning push--bottom">
-<b>All experiments started on or after January 21, 2015 have statistics computed by Optimizely Stats Engine.</b> For consistency with the Optimizely results page, we recommend you use the <a href="#get-stats">/stats</a> endpoint instead of the /results endpoint for all experiments started on or after January 21, 2015. You can continue to use the /results endpoint for all experiments, regardless of start date.</div>
+<b>Experiments started on or after January 21, 2015 also have statistics computed by Stats Engine.</b> For consistency with the Optimizely results page, we recommend you use the <a href="#get-stats">/stats</a> endpoint instead of the /results endpoint for those experiments.</div>
+
+The /results endpoint differs in several ways from the [/stats](#get-stats) endpoint.  In particular, it returns a **confidence** field instead of **statistical_significance**, and the value is computed using a traditional t-test rather than <a target="_blank" href="https://help.optimizely.com/hc/en-us/articles/200039895">Stats Engine</a>.  **confidence** represents the "Chance to Beat Baseline" that you may find on the results page for old experiments.
 
 The request requires an `experiment_id` and the response contains a list of JSON objects representing every combination of variations and goals that have been defined for that experiment. For example, if there are three variations and two goals defined for an experiment, the response will contain six JSON objects representing each `variation_id` and `goal_id` combination.
 


### PR DESCRIPTION
- Redo the copy in accordance with the fact that /stats now precedes /results.

- Tweak the copy to emphasize the fact that /stats is now the canonical endpoint, rather than /results.

- Fix a couple typos.

This is a follow-up to [PR 374](https://github.com/optimizely/developers.optimizely.com/pull/374).