### PR TITLE
Update Node activate() and track() code blocks to remove promise syntax

### DIFF
--- a/src/content/server/reference/activation/0-intro.md
+++ b/src/content/server/reference/activation/0-intro.md
@@ -60,16 +60,15 @@ code_examples:
       var userId = 'user123';
 
       // Conditionally activate an experiment for the provided user
-      optimizely.activate(experimentKey, userId)
-        .then(function(variation) {
-          if (variation === 'variation_a') {
-            // execute code for variation A
-          } else if (variation === 'variation_b') {
-            // execute code for variation B
-          } else {
-            // execute default code
-          }
-        });
+      var variation = optimizely.activate(experimentKey, userId);
+
+      if (variation === 'variation_a') {
+        // execute code for variation A
+      } else if (variation === 'variation_b') {
+        // execute code for variation B
+      } else {
+        // execute default code
+      }
 ---
 
 Use the `activate` function to run an experiment in your code.

--- a/src/content/server/reference/activation/1-targeting.md
+++ b/src/content/server/reference/activation/1-targeting.md
@@ -67,16 +67,15 @@ code_examples:
       var attributes = { 'device': 'iphone', 'ad_source': 'my_campaign' };
 
       // Conditionally activate an experiment for the provided user
-      optimizely.activate(experimentKey, userId, attributes)
-        .then(function(variation) {
-          if (variation === 'variation_a') {
-            // execute code for variation A
-          } else if (variation === 'variation_b') {
-            // execute code for variation B
-          } else {
-            // execute default code
-          }
-        });
+      var variation = optimizely.activate(experimentKey, userId, attributes);
+
+      if (variation === 'variation_a') {
+        // execute code for variation A
+      } else if (variation === 'variation_b') {
+        // execute code for variation B
+      } else {
+        // execute default code
+      }
 ---
 
 If you'd like to be able to segment your experiments based on attributes of your users, you should include the optional `attributes` argument to the `activate` function call. Optimizely will include these attributes when logging the experiment so you can segment them on the Optimizely results page.

--- a/src/content/server/reference/tracking/0-intro.md
+++ b/src/content/server/reference/tracking/0-intro.md
@@ -34,10 +34,7 @@ code_examples:
         var userId = 'user123';
 
         // Track a conversion event for the provided user
-        optimizely.track(eventKey, userId)
-          .then(function() {
-            // conversion has been tracked
-          });
+        optimizely.track(eventKey, userId);
 ---
 
 You can easily track Optimizely goals from your code as shown in the example to the right. Note that you don't need to pass the assigned experiments or variations; Optimizely will drop any conversion events for users that are not part of an experiment that includes the goal.

--- a/src/content/server/reference/tracking/1-attributes.md
+++ b/src/content/server/reference/tracking/1-attributes.md
@@ -42,10 +42,7 @@ code_examples:
         var attributes = { 'device': 'iPhone', 'ad_source': 'my_campaign' };
 
         // Track a conversion event for the provided user
-        optimizely.track(eventKey, userId, attributes)
-          .then(function() {
-            // conversion has been tracked
-          });
+        optimizely.track(eventKey, userId, attributes);
 ---
 
 If you'd like to be able to segment your experiments based on attributes of your users, you should include the optional `attributes` argument to the `track` function call. This is necessary even if you included the attributes in the corresponding `activate` call.


### PR DESCRIPTION
@delikat @aliabbasrizvi @vraja2 @mauerbac @jprovine 

Given the change in SDK method signatures to no longer return promises, I've updated `activate()` and `track()` blocks accordingly in SST docs. There was no other mentioning of promises in the written documentation, so only the blocks needed updating.