### PR TITLE
Include JSON schema validation and update constructor name in docs

### DIFF
--- a/src/content/server/reference/initialization/0-intro.md
+++ b/src/content/server/reference/initialization/0-intro.md
@@ -28,6 +28,12 @@ code_examples:
     request: |
       var datafile = {};
       var optimizely = optimizely.createInstance({ datafile: datafile });
+
+      // to skip JSON schema validation for the datafile (SDK versions 0.0.10 and above)
+      var optimizely = optimizely.createInstance({
+        datafile: datafile,
+        skipJSONValidation: true
+      });
 ---
 
 <div class="hidden visible" data-toggle-section="python-code">
@@ -57,3 +63,13 @@ To run experiments with Optimizely you'll need to instantiate an `Optimizely` ob
 
 <div class="hidden" data-toggle-section="java-code">
 To construct the `Optimizely` object, you'll need to provide a `datafile` String and an `EventHandler` object as arguments to the `Optimizely.builder` function. The `datafile` is a JSON representation of your project and contains all of the information needed to activate experiments and track events. For more information on the expected format of the datafile and how to get the most up-to-date version, see the [datafile](#datafile) section. `eventHandler` in the example to the right is instantiated as the provided asynchronous implementation.</div>
+
+<p>
+
+<div class="hidden" data-toggle-section="javascript-code">
+To run experiments with Optimizely you'll need to instantiate an `optimizely` object in your code. This object represents the state of an Optimizely project and can be used to both [activate experiments](#activation) and [track events](#tracking).</div>
+
+<p>
+
+<div class="hidden" data-toggle-section="javascript-code">
+To construct the `optimizely` object, you'll need to provide the `datafile` as an argument representing the JSON configuration of your project. The datafile contains all the instructions needed to activate experiments and track events. In SDK versions `0.0.10` and above, you can optionally pass in a `skipJSONValidation` property as `true` to skip JSON schema validation of the datafile upon `optimizely` instantiation. For more information on the expected format of the datafile and how to get the most up-to-date version, see the [datafile](#datafile) section.</div>

--- a/src/content/server/reference/initialization/1-parameters.md
+++ b/src/content/server/reference/initialization/1-parameters.md
@@ -58,5 +58,18 @@ code_examples:
         logger: defaultLogger.createLogger(),
       });
 ---
+<div class="hidden visible" data-toggle-section="python-code">
+  You can optionally provide a number of parameters to the `Optimizely` constructor to configure how the SDK behaves. See below for a full list of options that you can configure. If you plan on writing your own event dispatching, logging, or error handling, or would like to edit the default behavior provided by our SDKs, refer to the reference implementations in the SDK source code for examples.
+</div>
 
-You can optionally provide a number of parameters to the `Optimizely` constructor to configure how the SDK behaves. See below for a full list of options that you can configure. If you plan on writing your own event dispatching, logging, or error handling, or would like to edit the default behavior provided by our SDKs, refer to the reference implementations in the SDK source code for examples.
+<div class="hidden visible" data-toggle-section="java-code">
+  You can optionally provide a number of parameters to the `Optimizely` constructor to configure how the SDK behaves. See below for a full list of options that you can configure. If you plan on writing your own event dispatching, logging, or error handling, or would like to edit the default behavior provided by our SDKs, refer to the reference implementations in the SDK source code for examples.
+</div>
+
+<div class="hidden visible" data-toggle-section="ruby-code">
+  You can optionally provide a number of parameters to the `Optimizely` constructor to configure how the SDK behaves. See below for a full list of options that you can configure. If you plan on writing your own event dispatching, logging, or error handling, or would like to edit the default behavior provided by our SDKs, refer to the reference implementations in the SDK source code for examples.
+</div>
+
+<div class="hidden visible" data-toggle-section="javascript-code">
+  You can optionally provide a number of parameters to the `optimizely` constructor to configure how the SDK behaves. See below for a full list of options that you can configure. If you plan on writing your own event dispatching, logging, or error handling, or would like to edit the default behavior provided by our SDKs, refer to the reference implementations in the SDK source code for examples.
+</div>


### PR DESCRIPTION
Node SDK version `0.0.10` will introduce an optional parameter that can be used when creating the `optimizely` instance. Setting `skipJSONValidation` to `true` will skip JSON schema validation in instantiation, which can be a performance saver for users.

This diff also makes tweaks to change `Optimizely` to `optimizely` in all places where it discusses the constructor since the code blocks use `optimizely`.

@mauerbac @delikat @vraja2 @aliabbasrizvi 