### PR TITLE
Behavioral query fixes

### DIFF
--- a/src/content/behavior/query-objects/0-intro.md
+++ b/src/content/behavior/query-objects/0-intro.md
@@ -7,78 +7,49 @@ js: |
   {
     "version": "0.2"
   }
-
-  // Resulting value
+  // Result:
   [
     {
       "type": "pageview",
-      "name": "full_product_page",
-      "category": "product_detail",
+      "name": "AB_landing_page",
+      "category": "landing_page",
       "tags": {
-        "product_sku": "428977",
-        "product_desc": "Clamshell Button 12mm",
-        "product_cat": "button"
+        "theme": "urban_explorer"
       },
-      "time": 1447046231000
-    },
-    {
-      "type": "click",
-      "name": "learn_more",
-      "category": "product_detail",
-      "tags": {
-        product_sku: "428977",
-        product_desc: "Clamshell Button 12mm",
-        product_cat: "button",
-      }
-      "time": 1447047054000
-    },
-    {
-      "type": "click",
-      "name": "learn_more",
-      "category": "product_detail",
-      "tags": {
-        product_sku: "428977",
-        product_desc: "Clamshell Button 12mm",
-        product_cat: "button",
-      }
-      "time": 1447047060000
-    },
-    {
-      "type": "click",
-      "name": "learn_more",
-      "category": "product_detail",
-      "tags": {
-        product_sku: "428977",
-        product_desc: "Clamshell Button 12mm",
-        product_cat: "button",
-      }
-      "time": 1447047101000
-    },
-    {
-      "type": "custom",
-      "name": "add_to_cart",
-      "category": "product_detail",
-      "tags": {
-        product_sku: "428977",
-        product_desc: "Clamshell Button 12mm",
-        product_cat: "button",
-        quantity: 1
-      },
-      "time": 1447047135000
+      "time": 1111111111000
     },
     {
       "type": "pageview",
-      "name": "full_product_page",
+      "name": "AB_product_page",
       "category": "product_detail",
       "tags": {
-        product_sku: "428700",
-        product_desc: "Plastic Button 12mm Blue",
-        product_cat: "button"
+        "price": 12800,
+        "product_name": "Scout Backpack"
       },
-      "time": 1447048771000
+      "time": 1111111115000
+    },
+    {
+      "type": "click",
+      "name": "AB_add_to_cart",
+      "category": "add_to_cart",
+      "tags": {
+        "price": 12800,
+        "product_name": "Scout Backpack",
+        "quantity": 1
+      },
+      "time": 1111111119000
+    },
+    {
+      "type": "pageview",
+      "name": "AB_product_page",
+      "category": "product_detail",
+      "tags": {
+        "price": 14700,
+        "product_name": "Derby Tier Backpack"
+      },
+      "time": 2222222222000
     }
   ]
-  // TODO: pick a more concise example
 ---
 Behavioral queries are specified using JSON objects.
 

--- a/src/content/behavior/query-objects/0-intro.md
+++ b/src/content/behavior/query-objects/0-intro.md
@@ -5,7 +5,7 @@ anchor: query-objects
 js: |
   // Query object
   {
-    "version": 0.2
+    "version": "0.2"
   }
 
   // Resulting value

--- a/src/content/behavior/query-objects/1-version.md
+++ b/src/content/behavior/query-objects/1-version.md
@@ -5,7 +5,7 @@ anchor: version
 js: |
   // Query object
   {
-    "version": 0.2
+    "version": "0.2"
   }
 ---
 You must include a version number in each of your query objects.  This ensures that your query will always be evaluated the same, even if Optimizely introduces a backwards-incompatibile query format in the future.

--- a/src/content/behavior/query-objects/2-filter.md
+++ b/src/content/behavior/query-objects/2-filter.md
@@ -108,20 +108,19 @@ Note that you can filter by [`["age"]`](http://localhost:4000/behavior/#field-id
 These <span id="comparators">*comparators*</span> are usable on all fields:
 - `"eq"`: Requires the field value to roughly equal the filter's `value`.  For strings, this is case-insensitive, as well as leading- and trailing-whitespace-insensitive.
 - `"is"`: Requires the field value to exactly equal the filter's `value`.
-- `"in"`: Requires the field value to be contained in the filter's `value`, which must be an `["array", "of", "acceptable", "values", 1, 2, 3]`.  For strings, this is case-insensitive, as well as leading- and trailing-whitespace-insensitive.
+- `"in"`: Requires the field value to be contained in the filter's `value`, which must be an `["array", "of", "acceptable", "values", "such as", 2, "and", true]`.  For strings, this is case-insensitive, as well as leading- and trailing-whitespace-insensitive.
 - `"contains"`: Requires the field value, which must be an array, to contain the filter's `value` according to `indexOf`.  For strings, this is case-insensitive.
 - `"exists"`: Requires the field value to be defined; the filter need not specify a `value`.  This is only useful for tags, since top-level fields are defined for every event.
 
-The following <span id="string-comparators">*string comparators*</span> can be used on string fields like `type`,
-`name`, `category` and also on string tags:
+The following <span id="string-comparators">*string comparators*</span> can be used on string fields like `type`, `name`, `category` and also on string tags:
 - `"regex"`: Requires the field value to match the filter's `value`, which must be either a case-insensitive RegExp `"pattern"`, or a `["pattern", "flags"]` array
 
-The following <span id="number-comparators">*number comparators*</span> can be used on numeric fields like `time`, `age` and also on numeric tags like `revenue`:
-- `"gt"`: Requires the field value to be greater than the filter's `value`.
-- `"gte"`: Requires the field value to be greater than or equal to the filter's `value`.
-- `"lt"`: Requires the field value to be less than the filter's `value`.
-- `"lte"`: Requires the field value to be less than or equal to the filter's `value`.
-- `"between"`: Requires the field value to be in the inclusive interval specified by the filter's `value`, e.g. [123, 456].
+The following <span id="number-comparators">*number comparators*</span> can be used on numeric fields like `time`, `age` and also on numeric tags like `revenue`.  These comparators automatically reject non-numeric field values.
+- `"gt"`: Requires the field value to be greater than the filter's `value`, which must be a number.
+- `"gte"`: Requires the field value to be greater than or equal to the filter's `value`, which must be a number.
+- `"lt"`: Requires the field value to be less than the filter's `value`, which must be a number.
+- `"lte"`: Requires the field value to be less than or equal to the filter's `value`, which must be a number.
+- `"between"`: Requires the field value to be in the inclusive interval specified by the filter's `value`, which must be an array of two numbers.
 
 If `comparator` is omitted, it defaults to `"eq"`.
 

--- a/src/content/behavior/query-objects/2-filter.md
+++ b/src/content/behavior/query-objects/2-filter.md
@@ -3,7 +3,76 @@ template: sidebyside
 title: 2. filter
 anchor: filter
 js: |
-  // Query object
+  // Query for events that demonstrate interest in the "Scout Backpack".
+  {
+    "version": "0.2",
+    "filter": [
+      {
+        "field": ["tags", "product_name"],
+        "value": "Scout Backpack"
+      }
+    ]
+  }
+  // Result:
+  [
+    {
+      "type": "pageview",
+      "name": "AB_product_page",
+      "category": "product_detail",
+      "tags": {
+        "price": 12800,
+        "product_name": "Scout Backpack"
+      },
+      "time": 1111111115000
+    },
+    {
+      "type": "click",
+      "name": "AB_add_to_cart",
+      "category": "add_to_cart",
+      "tags": {
+        "price": 12800,
+        "product_name": "Scout Backpack",
+        "quantity": 1
+      },
+      "time": 1111111119000
+    }
+  ]
+
+  // Query for add-to-cart events where the price was at least $50.00.
+  {
+    "version": "0.2",
+    "filter": [
+      {
+        "field": ["type"],
+        "value": "click"
+      },
+      {
+        "field": ["category"],
+        "value": "add_to_cart"
+      },
+      {
+        "field": ["tags", "price"],
+        "comparator": "gte",
+        "value": 5000
+      }
+    ]
+  }
+  // Result:
+  [
+    {
+      "type": "click",
+      "name": "AB_add_to_cart",
+      "category": "add_to_cart",
+      "tags": {
+        "price": 12800,
+        "product_name": "Scout Backpack",
+        "quantity": 1
+      },
+      "time": 1111111119000
+    }
+  ]
+
+  // Query for pageview events that happened between 7 and 14 days ago.
   {
     "version": "0.2",
     "filter": [
@@ -12,33 +81,25 @@ js: |
         "value": "pageview"
       },
       {
-        "field": ["name"],
-        "value": "full_product_page"
-      },
-      {
-        "field": ["tags", "product_sku"],
-        "comparator": "exists"
-      }
-    ]
-  }
-
-  // Resulting value: list of pageview events from the `"full_product_page"` page that have a value for the `"product_sku"` tag,
-  // TODO
-
-  // Query object
-  {
-    "version": "0.2",
-    "filter": [
-      {
         "field": ["age"],
         "comparator": "between",
         "value": [7*24*60*60*1000, 14*24*60*60*1000]
       }
     ]
   }
-
-  // Resulting value: list of events that happened between 7 and 14 days ago.
-  // TODO
+  // Result:
+  [
+    {
+      "type": "pageview",
+      "name": "AB_product_page",
+      "category": "product_detail",
+      "tags": {
+        "price": 14700,
+        "product_name": "Derby Tier Backpack"
+      },
+      "time": 2222222222000
+    }
+  ]
 ---
 You can `filter` the results by passing in an array of filters, each comprising a [`field`](#field-identifiers), `comparator`, and `value`.  This narrows down the query to those events that match (all) filters.
 

--- a/src/content/behavior/query-objects/3-sort.md
+++ b/src/content/behavior/query-objects/3-sort.md
@@ -3,7 +3,7 @@ template: sidebyside
 title: 3. sort by time
 anchor: sort
 js: |
-  // Query object
+  // Query for events, sorted from newest to oldest.
   {
     "version": "0.2",
     "sort": [
@@ -13,8 +13,28 @@ js: |
       }
     ]
   }
-
-  // Resulting value: a list of events sorted from newest to oldest.
-  // TODO
+  // Result:
+  [
+    {
+      "type": "pageview",
+      "name": "AB_product_page",
+      "category": "product_detail",
+      "tags": {
+        "price": 14700,
+        "product_name": "Derby Tier Backpack"
+      },
+      "time": 2222222222000
+    },
+    ...,
+    {
+      "type": "pageview",
+      "name": "AB_landing_page",
+      "category": "landing_page",
+      "tags": {
+        "theme": "urban_explorer"
+      },
+      "time": 1111111111000
+    },
+  ]
 ---
 You can `sort` events by [`["time"]`](#field-identifiers), either `"ascending"` or `"descending"`.

--- a/src/content/behavior/query-objects/4-pick.md
+++ b/src/content/behavior/query-objects/4-pick.md
@@ -3,7 +3,7 @@ template: sidebyside
 title: 4. pick
 anchor: pick
 js: |
-  // Query object
+  // Query for tag values, sorted from most recent to least recent.
   {
     "version": "0.2",
     "sort": [
@@ -13,18 +13,14 @@ js: |
       }
     ],
     "pick": {
-      "field": ["name"]
+      "field": ["tags", "product_name"]
     }
   }
-
-  // Resulting value: a list of event names sorted from most recent to least recent.
+  // Result:
   [
-    "full_product_page",
-    "add_to_cart",
-    "learn_more",
-    "learn_more",
-    "learn_more",
-    "full_product_page"
+    "Derby Tier Backpack",
+    "Scout Backpack",
+    "Scout Backpack"
   ]
 ---
 You can `pick` the values for a single field out of an array of (potentially [filtered](#filter) and

--- a/src/content/behavior/query-objects/5-frequency-sort.md
+++ b/src/content/behavior/query-objects/5-frequency-sort.md
@@ -3,11 +3,11 @@ template: sidebyside
 title: 5. sort by frequency
 anchor: frequency-sort
 js: |
-  // Query object
+  // Query for unique tag values sorted from most frequent to least frequent
   {
     "version": "0.2",
     "pick": {
-      "field": ["name"]
+      "field": ["tags", "product_name"]
     },
     "sort": [
       {
@@ -16,12 +16,10 @@ js: |
       }
     ]
   }
-
-  // Resulting value: a list of unique event names sorted from most frequent to least frequent:
+  // Result:
   [
-    "learn_more",
-    "full_product_page",
-    "add_to_cart"
+    "Scout Backpack",
+    "Derby Tier Backpack"
   ]
 ---
 If field values are being [picked](#pick) out of events, you can `sort` those values by `["frequency"]`, either `"ascending"` or `"descending"`.

--- a/src/content/behavior/query-objects/6-reduce.md
+++ b/src/content/behavior/query-objects/6-reduce.md
@@ -62,4 +62,4 @@ The following <span id="mathematical-aggregators">*mathematical aggregators*</id
 - `"max"`: Reduce the list by choosing the largest of the numeric values.
 - `"min"`: Reduce the list by choosing the smallest of the numeric values.
 
-Non-numeric values are ignored when evaluating a mathematical aggregator, as if those values didn't exist at all.  This ensures, for example, that an `"avg"` computation is not diluted through zero-filling of `undefined` values.  Note that JavaScript numbers like `NaN`, `+Infinity`, and `-Infinity` are still recognized and can strong affect the result of the aggregation.
+Non-numeric values are ignored when evaluating a mathematical aggregator, as if those values didn't exist at all.  This ensures, for example, that an `"avg"` computation is not diluted through zero-filling of `undefined` values.  Note that JavaScript numbers like `NaN`, `+Infinity`, and `-Infinity` are still recognized and can severely affect the result of the aggregation.

--- a/src/content/behavior/query-objects/6-reduce.md
+++ b/src/content/behavior/query-objects/6-reduce.md
@@ -3,7 +3,7 @@ template: sidebyside
 title: 6. reduce
 anchor: reduce
 js: |
-  // Query object
+  // Query for the single most recent event
   {
     "version": "0.2",
     "sort": [
@@ -18,23 +18,37 @@ js: |
       "n": 0
     }
   }
+  // Result:
+  {
+    "type": "pageview",
+    "name": "AB_product_page",
+    "category": "product_detail",
+    "tags": {
+      "price": 14700,
+      "product_name": "Derby Tier Backpack"
+    },
+    "time": 2222222222000
+  }
 
-  // Resulting value: the single most recent event.
-
-  // Query object
+  // Query for the average price across all product page views
   {
     "version": "0.2",
+    "filter": [
+      {
+        "field": ["type"],
+        "value": "pageview"
+      }
+    ],
     "pick": {
-      "field": ["tags", "revenue"],
+      "field": ["tags", "price"],
     },
     // Reduce a list of picked field values into a single value.
     "reduce": {
-      "aggregator": "sum"
+      "aggregator": "avg"
     }
   }
-
-  // Resulting value: the sum of all defined values for the "revenue" tag.
-  4200
+  // Result:
+  13750
 ---
 You can `reduce` a list of values into a single value using an `aggregator`.
 

--- a/src/content/javascript/personalization/index.md
+++ b/src/content/javascript/personalization/index.md
@@ -426,8 +426,12 @@ This listener fires whenever a page is activated, either due to URL targeting or
 
 <h4 id="query" class="subLink">query</h4>
 
+This API function runs a behavioral query over the [events](https://help.optimizely.com/Get_Started/Six_core_concepts_of_Optimizely_Personalization#events) that have taken place on this device.
+
+Currently, the API only considers events that took place before the most recent activation of the Optimizely snippet.  You must reload the page if you want to query over events that took place on the current page load.
+
 ##### *Parameters*
-This API accepts a behavioral [query object](/behavior/#query-objects).
+- `query` (object): A [behavioral query object](/behavior/#query-objects)
 
 ##### *Returns*
 Depending on which clauses are included in the specified query object, this API will return one of the following types of values:
@@ -464,7 +468,7 @@ behavior.query({
 
 <h4 id="getAttributeValue" class="subLink">getAttributeValue</h4>
 
-This utility returns the current customer's value for a [content-enabled](https://help.optimizely.com/hc/en-us/articles/216497887) profile attribute.
+This API function returns the current customer's value for a [content-enabled](https://help.optimizely.com/hc/en-us/articles/216497887) profile attribute.
 
 ##### *Parameters*
 - `datasourceId` (number): Required
@@ -497,7 +501,7 @@ dcp.getAttributeValue({datasourceId: 123, attributeName: 'Preferred Locale'});
 
 <h4 id="waitForAttributeValue" class="subLink">waitForAttributeValue</h4>
 
-This utility returns a `Promise` that will be resolved as soon as Optimizely receives the current customer's value for a [content-enabled](https://help.optimizely.com/hc/en-us/articles/216497887) profile attribute.
+This API function returns a `Promise` that will be resolved as soon as Optimizely receives the current customer's value for a [content-enabled](https://help.optimizely.com/hc/en-us/articles/216497887) profile attribute.
 
 ##### *Parameters*
 - `datasourceId` (number): Required


### PR DESCRIPTION
* Exemplify the correct v0.2 version specifier (string instead of number)
* Note that behavioral queries only apply to "past" events
* Exemplify behavioral queries using a running example from Attic & Button
* Clarify the behavior of the query API given various input types