### PR TITLE
Add npm module links to developer docs

### DIFF
--- a/src/content/server/reference/install/0-intro.md
+++ b/src/content/server/reference/install/0-intro.md
@@ -49,6 +49,11 @@ The gem for the Ruby SDK is distributed through [RubyGems](https://rubygems.org/
 
 <p>
 
+<div class="hidden" data-toggle-section="javascript-code">
+The Node SDK is distributed through [npm](https://www.npmjs.com/package/optimizely-server-sdk). To install, simply run `npm install optimizely-server-sdk --save`.
+</div>
+
+<p>
 
 <div class="attention attention--warning push--bottom">
 Our server-side SDKs are not yet generally available to Optimizely customers. Please contact [developers@optimizely.com](mailto:developers@optimizely.com) if you are interested in getting early access or giving us feedback.

--- a/src/content/server/reference/tracking/1-web-tracking.md
+++ b/src/content/server/reference/tracking/1-web-tracking.md
@@ -4,7 +4,7 @@ title: Tracking on the web
 anchor: webtracking
 ---
 
-If you'd like to track events on the web, client-side (via JavaScript) instead of on the server, you can use the JavaScript SDK. Please email <developers@optimizely.com> to get a hold of the SDK.
+If you'd like to track events on the web, client-side (via JavaScript) instead of on the server, you can use the JavaScript SDK. This SDK is available via [npm](https://www.npmjs.com/package/optimizely-client-sdk).
 
 Instructions for using the SDK:
 


### PR DESCRIPTION
This adds links to Node and JavaScript SDKs in the developer docs

@mauerbac @jprovine @mikeng13 @delikat @vraja2 